### PR TITLE
added prism repo to list

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -2,3 +2,4 @@ html-preview: https://github.com/chriskempson/base16-html-preview
 shell: https://github.com/chriskempson/base16-shell
 textmate: https://github.com/chriskempson/base16-textmate
 vim: https://github.com/chriskempson/base16-vim
+prism: https://github.com/atelierbram/base16-prism


### PR DESCRIPTION
I hope I did formatted [Base16 Prism](https://github.com/atelierbram/base16-prism) in the right way, but couldn't make this build the themes correctly myself with the new php builder.

Probably should be a `dark.mustache` and `light.mustache` there in stead of the `default.mustache` as well.