### PR TITLE
Added template for Terminal.app

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -1,4 +1,5 @@
 html-preview: https://github.com/chriskempson/base16-html-preview
 shell: https://github.com/chriskempson/base16-shell
 textmate: https://github.com/chriskempson/base16-textmate
+terminal-app: https://github.com/vbwx/base16-terminal-app
 vim: https://github.com/chriskempson/base16-vim


### PR DESCRIPTION
I revived the Base16 template for OS X’s Terminal; requires my fork of base16-builder-php.