### PR TITLE
Add emacs templates from fork

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -1,3 +1,4 @@
+emacs: https://github.com/belak/base16-emacs
 html-preview: https://github.com/chriskempson/base16-html-preview
 shell: https://github.com/chriskempson/base16-shell
 textmate: https://github.com/chriskempson/base16-textmate


### PR DESCRIPTION
Note that this is from a fork currently, as the existing maintainer has not touched the templates in quite a while.

Once this is merged in here, I'll go through the process of replacing the package in melpa (the emacs package archive).