### PR TITLE
Add putty templates compatible with new builder

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -3,6 +3,7 @@ highlight: https://github.com/bezhermoso/base16-highlight
 html-preview: https://github.com/chriskempson/base16-html-preview
 mintty: https://github.com/iamthad/base16-mintty
 prism: https://github.com/atelierbram/base16-prism
+putty: https://github.com/abravalheri/base16-putty
 qtcreator: https://github.com/ilpianista/base16-qtcreator
 shell: https://github.com/chriskempson/base16-shell
 textmate: https://github.com/chriskempson/base16-textmate


### PR DESCRIPTION
Attempt to update PuTTY support.

Neither benjojo/base-16-putty nor staticaland/base16-putty seem to support latest schemas. Moreover the `.reg` file template is not available...