### PR TITLE
Add c_header template

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -15,3 +15,4 @@ windows-command-prompt: https://github.com/iamthad/base16-windows-command-prompt
 xfce4-terminal: https://github.com/afg984/base16-xfce4-terminal
 xresources: https://github.com/chriskempson/base16-xresources
 monodevelop: https://github.com/netpyoung/base16-monodevelop
+c_header: https://github.com/m1sports20/base16-c_header


### PR DESCRIPTION
Generates a standard c header of base16 colors.  Use for any c or c++ project.  I am currently using it with dwm