### PR TITLE
Add base16-rofi template

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -13,6 +13,7 @@ monodevelop: https://github.com/netpyoung/base16-monodevelop
 prism: https://github.com/atelierbram/base16-prism
 putty: https://github.com/abravalheri/base16-putty
 qtcreator: https://github.com/ilpianista/base16-qtcreator
+rofi: https://github.com/0xdec/base16-rofi
 shell: https://github.com/chriskempson/base16-shell
 termite: https://github.com/khamer/base16-termite
 textmate: https://github.com/chriskempson/base16-textmate


### PR DESCRIPTION
[Rofi](https://github.com/DaveDavenport/rofi) is a window switcher, run dialog, and dmenu replacement. Its theme is set either through `~/.Xresources` or `~/.config/rofi/config`. This template uses the latter so as not to conflict with base16-xresources.