### PR TITLE
Add zathura to the list of source templates

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -21,3 +21,4 @@ vim: https://github.com/chriskempson/base16-vim
 windows-command-prompt: https://github.com/iamthad/base16-windows-command-prompt
 xfce4-terminal: https://github.com/afg984/base16-xfce4-terminal
 xresources: https://github.com/chriskempson/base16-xresources
+zathura: https://github.com/nicodebo/base16-zathura


### PR DESCRIPTION
zathura source templates are available at the following adress:
https://github.com/nicodebo/base16-zathura