### PR TITLE
Add alacritty template to list

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -1,4 +1,5 @@
 # Please order list alphanumerically
+alacritty: https://github.com/aaron-williamson/base16-alacritty
 c_header: https://github.com/m1sports20/base16-c_header
 crosh: https://github.com/philj56/base16-crosh
 dunst: https://github.com/khamer/base16-dunst


### PR DESCRIPTION
I created a repo for [Alacritty](https://github.com/jwilm/alacritty) color configurations. Feel free to take a look here: https://github.com/aaron-williamson/base16-alacritty