### PR TITLE
Add prompt-toolkit templates repo

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -12,6 +12,7 @@ kakoune: https://github.com/leira/base16-kakoune
 mintty: https://github.com/iamthad/base16-mintty
 monodevelop: https://github.com/netpyoung/base16-monodevelop
 prism: https://github.com/atelierbram/base16-prism
+prompt-toolkit: https://github.com/memeplex/base16-prompt-toolkit
 putty: https://github.com/abravalheri/base16-putty
 qtcreator: https://github.com/ilpianista/base16-qtcreator
 shell: https://github.com/chriskempson/base16-shell


### PR DESCRIPTION
This is for coloring the output of prompt toolkit, specially designed for ipython.