### PR TITLE
Add Xcode template (base16-xcode).

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -29,6 +29,7 @@ tilix: https://github.com/karlding/base16-tilix
 vim: https://github.com/chriskempson/base16-vim
 vis: https://github.com/pshevtsov/base16-vis
 windows-command-prompt: https://github.com/iamthad/base16-windows-command-prompt
+xcode: https://github.com/kreeger/base16-xcode
 xfce4-terminal: https://github.com/afg984/base16-xfce4-terminal
 xresources: https://github.com/chriskempson/base16-xresources
 zathura: https://github.com/nicodebo/base16-zathura


### PR DESCRIPTION
Uses the new 0.9.0 builder spec.