### PR TITLE
add iterm2 template

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -11,6 +11,7 @@ gtk2: https://github.com/dawikur/base16-gtk2
 highlight: https://github.com/bezhermoso/base16-highlight
 html-preview: https://github.com/chriskempson/base16-html-preview
 i3: https://github.com/khamer/base16-i3
+iterm2: https://github.com/martinlindhe/base16-iterm2
 kakoune: https://github.com/leira/base16-kakoune
 konsole: https://github.com/cskeeters/base16-konsole
 mintty: https://github.com/iamthad/base16-mintty


### PR DESCRIPTION
As discussed in https://github.com/chriskempson/base16/pull/115, adding my fork of base16-iterm2