### PR TITLE
Add Windows concfg utility

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -3,6 +3,7 @@ alacritty: https://github.com/aaron-williamson/base16-alacritty
 blink: https://github.com/niklaas/base16-blink.git
 bbedit: https://github.com/hrbn/base16-bbedit
 c_header: https://github.com/m1sports20/base16-c_header
+concfg: https://github.com/tknarr/base16-concfg
 conemu: https://github.com/martinlindhe/base16-conemu 
 crosh: https://github.com/philj56/base16-crosh
 dunst: https://github.com/khamer/base16-dunst


### PR DESCRIPTION
Add a template repository for the Windows concfg utility for configuring console and PowerShell window colors in Windows.