### PR TITLE
Update list.yaml to include base16-pywal

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -25,6 +25,7 @@ prism: https://github.com/atelierbram/base16-prism
 prompt-toolkit: https://github.com/memeplex/base16-prompt-toolkit
 putty: https://github.com/abravalheri/base16-putty
 pygments: https://github.com/mohd-akram/base16-pygments
+pywal: https://github.com/metalelf0/base16-pywal
 qtcreator: https://github.com/ilpianista/base16-qtcreator
 rofi: https://github.com/0xdec/base16-rofi
 shell: https://github.com/chriskempson/base16-shell


### PR DESCRIPTION
[pywal](https://github.com/dylanaraps/pywal) is a tool written by the amazing @dylanaraps to system-wide apply color palettes. This template allows building colorschemes for his tool, so you can apply base16 colorschemes to all the apps pywal supports.