### PR TITLE
Add i3status-rust template

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -13,6 +13,7 @@ gtk2: https://github.com/dawikur/base16-gtk2
 highlight: https://github.com/bezhermoso/base16-highlight
 html-preview: https://github.com/chriskempson/base16-html-preview
 i3: https://github.com/khamer/base16-i3
+i3status-rust: https://github.com/mystfox/base16-i3status-rust
 iterm2: https://github.com/martinlindhe/base16-iterm2
 jetbrains: https://github.com/adilosa/base16-jetbrains
 joe: https://github.com/jjjordan/base16-joe


### PR DESCRIPTION
[i3status-rust](https://github.com/greshake/i3status-rust) is a replacement for i3status. But it has its own theming and I wanted it to automatically fit with the rest of my i3 bar, so I wrote a template, [base16-i3status-rust](https://github.com/mystfox/base16-i3status-rust). Haven't seen any problems with it, though color choices might want to be revised.