### PR TITLE
Add base16-qutebrowser

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -26,6 +26,7 @@ prompt-toolkit: https://github.com/memeplex/base16-prompt-toolkit
 putty: https://github.com/abravalheri/base16-putty
 pygments: https://github.com/mohd-akram/base16-pygments
 qtcreator: https://github.com/ilpianista/base16-qtcreator
+qutebrowser: https://github.com/theova/base16-qutebrowser
 rofi: https://github.com/0xdec/base16-rofi
 shell: https://github.com/chriskempson/base16-shell
 scide: https://github.com/brunoro/base16-scide


### PR DESCRIPTION
Please add [base16-qutebrowser](https://github.com/theova/base16-qutebrowser) to the list.

Thank you for your work! base16 is just fantastic!