### PR TITLE
add base16-firefox template

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -8,6 +8,7 @@ conemu: https://github.com/martinlindhe/base16-conemu
 crosh: https://github.com/philj56/base16-crosh
 dunst: https://github.com/khamer/base16-dunst
 emacs: https://github.com/belak/base16-emacs
+firefox: https://github.com/grmat/base16-firefox
 fzf: https://github.com/nicodebo/base16-fzf
 gnome-terminal: https://github.com/aaron-williamson/base16-gnome-terminal
 gtk2: https://github.com/dawikur/base16-gtk2


### PR DESCRIPTION
I'm not sure if this is desired here, as some additional work is necessary to get the theme working in Firefox, apart from plain text file patching, but it helps me having a more consistent desktop look & feel. The template will create a valid JSON description of a Firefox theme, but the user needs to load it as an addon, additional info and files are in the repo. A finished WebExtension with the ability of selecting themes at runtime has also been pushed to [addons.mozilla.org](https://addons.mozilla.org/firefox/addon/base16/).