### PR TITLE
Add Godot template

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -11,6 +11,7 @@ dunst: https://github.com/khamer/base16-dunst
 emacs: https://github.com/belak/base16-emacs
 fzf: https://github.com/nicodebo/base16-fzf
 gnome-terminal: https://github.com/aaron-williamson/base16-gnome-terminal
+godot: https://github.com/Calinou/base16-godot
 gtk2: https://github.com/dawikur/base16-gtk2
 highlight: https://github.com/bezhermoso/base16-highlight
 html-preview: https://github.com/chriskempson/base16-html-preview


### PR DESCRIPTION
This adds a template for the [Godot](https://godotengine.org/) script editor.