### PR TITLE
Removes bbedit theme, does not exist

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -2,7 +2,6 @@
 alacritty: https://github.com/aaron-williamson/base16-alacritty
 binary-ninja: https://github.com/evanrichter/base16-binary-ninja
 blink: https://github.com/niklaas/base16-blink.git
-bbedit: https://github.com/hrbn/base16-bbedit
 c_header: https://github.com/m1sports20/base16-c_header
 concfg: https://github.com/h404bi/base16-concfg
 conemu: https://github.com/martinlindhe/base16-conemu 


### PR DESCRIPTION
This (and possibly other) themes do not exists. The url causes problems when tryng to build them with some builders.

