### PR TITLE
Add base16 template for cmus.

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -3,6 +3,7 @@ alacritty: https://github.com/aaron-williamson/base16-alacritty
 binary-ninja: https://github.com/evanrichter/base16-binary-ninja
 blink: https://github.com/niklaas/base16-blink.git
 c_header: https://github.com/m1sports20/base16-c_header
+cmus: https://github.com/a-vrma/base16-cmus
 concfg: https://github.com/h404bi/base16-concfg
 conemu: https://github.com/martinlindhe/base16-conemu 
 console2: https://github.com/AFulgens/base16-console2


### PR DESCRIPTION
cmus is a small, fast and powerful
console music player for Unix-like operating systems.
Its homepage is https://cmus.github.io/