### PR TITLE
Add hugo

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -15,6 +15,7 @@ godot: https://github.com/Calinou/base16-godot
 gtk2: https://github.com/dawikur/base16-gtk2
 highlight: https://github.com/bezhermoso/base16-highlight
 html-preview: https://github.com/chriskempson/base16-html-preview
+hugo: https://github.com/yawpitch/base16-hugo
 i3: https://github.com/khamer/base16-i3
 i3status-rust: https://github.com/mystfox/base16-i3status-rust
 iterm2: https://github.com/martinlindhe/base16-iterm2


### PR DESCRIPTION
Adds [hugo](https://github.com/yawpitch/base16-hugo) templates for anyone that wants to snazz up their syntax highlighting.