### PR TITLE
Add fish template

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -9,6 +9,7 @@ console2: https://github.com/AFulgens/base16-console2
 crosh: https://github.com/philj56/base16-crosh
 dunst: https://github.com/khamer/base16-dunst
 emacs: https://github.com/belak/base16-emacs
+fish: https://github.com/tomyun/base16-fish
 fzf: https://github.com/nicodebo/base16-fzf
 gnome-terminal: https://github.com/aaron-williamson/base16-gnome-terminal
 godot: https://github.com/Calinou/base16-godot


### PR DESCRIPTION
[base16-fish](https://github.com/tomyun/base16-fish) is a new shell template specifically made for fish shell based on [base16-shell](https://github.com/chriskempson/base16-shell).