### PR TITLE
Remove radare2 repository

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -37,7 +37,6 @@ pywal: https://github.com/metalelf0/base16-pywal
 qownnotes: https://github.com/themix-project/base16-template-qOwnNotes
 qtcreator: https://github.com/ilpianista/base16-qtcreator
 qutebrowser: https://github.com/theova/base16-qutebrowser
-radare2: https://github.com/jtalowell/base16-radare2
 rofi: https://gitlab.com/0xdec/base16-rofi
 scide: https://github.com/brunoro/base16-scide
 shell: https://github.com/chriskempson/base16-shell


### PR DESCRIPTION
404 when visiting that URL. This is causing issues in pybase16-builder and likely other tools.

See also: https://github.com/InspectorMustache/base16-builder-python/issues/17
