### PR TITLE
Add vimiv template repository

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -57,6 +57,7 @@ tilix: https://github.com/karlding/base16-tilix
 tmux: https://github.com/mattdavis90/base16-tmux
 vim-airline-themes: https://github.com/dawikur/base16-vim-airline-themes
 vim: https://github.com/chriskempson/base16-vim
+vimiv: https://github.com/karlch/base16-vimiv
 vis: https://github.com/pshevtsov/base16-vis
 vscode: https://github.com/golf1052/base16-vscode
 waybar: https://github.com/mnussbaum/base16-waybar


### PR DESCRIPTION
See https://github.com/chriskempson/base16/pull/222 for the related pull-request in the main base16 repository.