### PR TITLE
base16-vtrgb

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -59,6 +59,7 @@ vim-airline-themes: https://github.com/dawikur/base16-vim-airline-themes
 vim: https://github.com/chriskempson/base16-vim
 vis: https://github.com/pshevtsov/base16-vis
 vscode: https://github.com/golf1052/base16-vscode
+vtrgb: https://github.com/coderonline/base16-vtrgb
 waybar: https://github.com/mnussbaum/base16-waybar
 windows-command-prompt: https://github.com/iamthad/base16-windows-command-prompt
 windows-terminal: https://github.com/wuqs-net/base16-windows-terminal


### PR DESCRIPTION
I made a port to allow the base16 color-schemes to be applied in the virtual terminals using the `setvtrgb` tool from the [kbd](https://github.com/legionus/kbd/issues) package. It has also been prepared to work in an early boot environment as a systemd-service, so that boot messages can be displayed according to the configured color scheme.

See also: https://github.com/chriskempson/base16/pull/284