### PR TITLE
Add template for Gtk3 theme FlatColor

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -15,6 +15,7 @@ everything: https://github.com/spitfire05/base16-everything
 fzf: https://github.com/nicodebo/base16-fzf
 gnome-terminal: https://github.com/aaron-williamson/base16-gnome-terminal
 godot: https://github.com/Calinou/base16-godot
+gtk-flatcolor: https://github.com/Misterio77/base16-gtk-flatcolor
 gtk2: https://github.com/dawikur/base16-gtk2
 highlight: https://github.com/bezhermoso/base16-highlight
 html-preview: https://github.com/chriskempson/base16-html-preview


### PR DESCRIPTION
Hello!
I just created a template for wpgtk's theme, FlatColor.
It's a gtk3 theme with simple variables for colors, so it's very very easy to integrate it with base16.

As far as i know, this is the first gtk3 template for base16, so i think it will help make base16 setups even better.