### PR TITLE
Added the gtksourceview3 template repository

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -17,6 +17,7 @@ gnome-terminal: https://github.com/aaron-williamson/base16-gnome-terminal
 godot: https://github.com/Calinou/base16-godot
 gtk-flatcolor: https://github.com/Misterio77/base16-gtk-flatcolor
 gtk2: https://github.com/dawikur/base16-gtk2
+gtksouceview3: https://github.com/GarkGarcia/base16-gtksourceview3
 highlight: https://github.com/bezhermoso/base16-highlight
 html-preview: https://github.com/chriskempson/base16-html-preview
 hugo: https://github.com/yawpitch/base16-hugo


### PR DESCRIPTION
I've written a template for GtkSourceView (version 3). You can check it out in [here](https://github.com/GarkGarcia/base16-gtksourceview3).