### PR TITLE
Add qt5ct template repo

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -39,6 +39,7 @@ putty: https://github.com/abravalheri/base16-putty
 pygments: https://github.com/mohd-akram/base16-pygments
 pywal: https://github.com/metalelf0/base16-pywal
 qownnotes: https://github.com/themix-project/base16-template-qOwnNotes
+qt5ct: https://github.com/mnussbaum/base16-qt5ct
 qtcreator: https://github.com/ilpianista/base16-qtcreator
 qutebrowser: https://github.com/theova/base16-qutebrowser
 #radare2: https://github.com/jtalowell/base16-radare2


### PR DESCRIPTION
This adds a template repo for [qt5ct](https://sourceforge.net/projects/qt5ct/). qt5ct lets you theme Qt apps when using a light-weight DE like i3. You can check out the template repo at [base16-qt5ct](https://github.com/mnussbaum/base16-qt5ct)