### PR TITLE
Added Jetbrains IDE Themes

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -26,6 +26,7 @@ i3status: https://github.com/Eluminae/base16-i3status
 i3status-rust: https://github.com/mystfox/base16-i3status-rust
 iterm2: https://github.com/martinlindhe/base16-iterm2
 jetbrains: https://github.com/adilosa/base16-jetbrains
+jetbrains-ide: https://github.com/ShiromMakkad/base16-jetbrains-ide
 joe: https://github.com/jjjordan/base16-joe
 kakoune: https://github.com/aprilarcus/base16-kakoune
 kitty: https://github.com/kdrag0n/base16-kitty


### PR DESCRIPTION
The current Jetbrains themes only style the editor and don't touch the rest of the UI. This repository adds support for the whole IDE. 