### PR TITLE
Add base16-nvim

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -37,6 +37,7 @@ luakit: https://github.com/twnaing/base16-luakit
 mako: https://github.com/Eluminae/base16-mako
 mintty: https://github.com/iamthad/base16-mintty
 monodevelop: https://github.com/netpyoung/base16-monodevelop
+nvim: https://github.com/wincent/base16-nvim
 polybar: https://github.com/Misterio77/base16-polybar
 prism: https://github.com/atelierbram/base16-prism
 prompt-toolkit: https://github.com/memeplex/base16-prompt-toolkit


### PR DESCRIPTION
[This](https://github.com/wincent/base16-nvim) is a straight port of base16-vim to Lua, for use in Neovim.