### PR TITLE
feat(list): add base16-nvim for neovim to template list

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -34,6 +34,7 @@ kakoune: https://github.com/aprilarcus/base16-kakoune
 kitty: https://github.com/kdrag0n/base16-kitty
 konsole: https://github.com/cskeeters/base16-konsole
 luakit: https://github.com/twnaing/base16-luakit
+neovim: https://github.com/bradcush/base16-nvim
 mako: https://github.com/Eluminae/base16-mako
 mintty: https://github.com/iamthad/base16-mintty
 monodevelop: https://github.com/netpyoung/base16-monodevelop


### PR DESCRIPTION
Written in `lua` porting over some general colors from exactly was written in `base16-vim`. Includes the addition of highlight groups specifically for the Neovim like built-in LSP, Treesitter syntax highlighting, and other specifics. (I've chosen to leave out some highlight groups related to a few plugins or those that are language specific.)

Update: I've just noticed there has been a PR opened right before this one porting `base16-vim` directly without additional highlight groups for the Neovim built-in LSP as well as Treesitter. Hoping this PR can still be considered as it includes more highlight groups related to Neovim.