### PR TITLE
Fixed incorrect URIs for xresources template

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,6 @@ To add your own template, submit a pull request and add your repository to the l
 * [Wofi](https://hg.sr.ht/~scoopta/wofi) maintained by [knezi](https://sr.ht/~knezi)
 * [Xcode](https://github.com/kreeger/base16-xcode) maintained by [kreeger](https://github.com/kreeger)
 * [XFCE4 Terminal](https://github.com/afq984/base16-xfce4-terminal) maintained by [afq984](https://github.com/afq984)
-* [Xresources](https://github.com/binaryplease/base16-xresources) maintained by [binaryplease](https://github.com/binaryplease)
+* [Xresources](https://github.com/base16-project/base16-xresources) maintained by [binaryplease](https://github.com/binaryplease)
 * [Xshell](https://github.com/h404bi/base16-xshell) maintained by [h404bi](https://github.com/h404bi)
 * [zathura](https://github.com/HaoZeke/base16-zathura) maintained by [HaoZeke](https://github.com/HaoZeke)

--- a/list.yaml
+++ b/list.yaml
@@ -83,7 +83,7 @@ wmaker: https://github.com/d-torrance/base16-wmaker
 wofi: https://git.sr.ht/~knezi/base16-wofi
 xcode: https://github.com/kreeger/base16-xcode
 xfce4-terminal: https://github.com/afq984/base16-xfce4-terminal
-xresources: https://github.com/chriskempson/base16-xresources
+xresources: https://github.com/base16-project/base16-xresources
 xshell: https://github.com/h404bi/base16-xshell
 zathura: https://github.com/nicodebo/base16-zathura
 


### PR DESCRIPTION
The xresources URI in list.yaml returned a 404. The same URI in README.md redirects to the base16-project namespace, so I assume the PR contains the correct URIs, but I'm not sure if the maintainer is correct. Sorry for the trivial change, it breaks unit tests on https://github.com/InspectorMustache/base16-builder-python . 