### PR TITLE
Add base16-screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ To add your own template, submit a pull request and add your repository to the l
 * [qutebrowser](https://github.com/theova/base16-qutebrowser) maintaned by [theova](https://github.com/theova)
 * [Rofi](https://gitlab.com/0xdec/base16-rofi) maintained by [0xdec](https://gitlab.com/0xdec)
 * [Scide](https://github.com/brunoro/base16-scide) maintained by [brunoro](https://github.com/brunoro)
+* [Screen](https://github.com/quiteclose/base16-screen) maintained by [QuiteClose](https://github.com/quiteclose)
 * [Shell](https://github.com/chriskempson/base16-shell) maintained by [chriskempson](https://github.com/chriskempson)
 * [st](https://github.com/honza/base16-st) maintained by [honza](https://github.com/honza)
 * [StumpWM](https://github.com/tpine/base16-stumpwm) maintained by [tpine](https://github.com/tpine)

--- a/list.yaml
+++ b/list.yaml
@@ -56,6 +56,7 @@ qutebrowser: https://github.com/theova/base16-qutebrowser
 #radare2: https://github.com/jtalowell/base16-radare2
 rofi: https://gitlab.com/0xdec/base16-rofi
 scide: https://github.com/brunoro/base16-scide
+screen: https://github.com/quiteclose/base16-screen
 shell: https://github.com/chriskempson/base16-shell
 spotify: https://github.com/misterio77/base16-spotify
 st: https://github.com/dgmulf/base16-st


### PR DESCRIPTION
This PR:

* Claims the **Green Screen** theme (See: [base16-unclaimed-schemes/greenscreen.yaml](https://github.com/chriskempson/base16-unclaimed-schemes/blob/master/greenscreen.yaml))
* Adds a clone of Green Screen that uses an amber palette (called **Amber Screen**)

Samples:

|Green Screen|Amber Screen|
|---|---|
| ![base16-greenscreen](https://github.com/user-attachments/assets/43994725-c24d-41ea-92a6-a1359ae4b8a5) | ![base16-amberscreen](https://github.com/user-attachments/assets/30485611-d203-4c1c-a712-693592e612fb) |
